### PR TITLE
Fix texture 2d in material setup

### DIFF
--- a/addons/pixpal_tools/Imphenzia/PixPal/Resources/VS_ImphenziaPixPal.tres
+++ b/addons/pixpal_tools/Imphenzia/PixPal/Resources/VS_ImphenziaPixPal.tres
@@ -16,9 +16,11 @@ function = 31
 
 [sub_resource type="VisualShaderNodeTexture" id="VisualShaderNodeTexture_l3ee6"]
 texture = ExtResource("1_a0yjt")
+texture_type = 1
 
 [sub_resource type="VisualShaderNodeTexture" id="VisualShaderNodeTexture_khv4d"]
 texture = ExtResource("2_k4gmu")
+texture_type = 1
 
 [sub_resource type="VisualShaderNodeFloatConstant" id="VisualShaderNodeFloatConstant_op67b"]
 constant = 0.141
@@ -50,8 +52,8 @@ code = "shader_type spatial;
 render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert, specular_schlick_ggx;
 
 uniform sampler2D tex_frg_6;
-uniform sampler2D tex_frg_14;
-uniform sampler2D tex_frg_13;
+uniform sampler2D tex_frg_14 : source_color;
+uniform sampler2D tex_frg_13 : source_color;
 
 
 


### PR DESCRIPTION
**Issue**: I noticed that colors become more washed out when applying your material. 
**Solution**: change this parameter for Texture2D with Base Color:
<img width="219" height="314" alt="image" src="https://github.com/user-attachments/assets/69416ded-f0df-4097-987d-32d188b867d2" />

I think the same should be applied to the emission as well. (but you can't see the difference on my images)

I hesitate to make the same change for Attributes, because it contains non-color data. But in my test cases it looked better as well. Still, I'd leave it as it is. I can make a note in the Readme if you like. 

**Illustration**

I tested the problem and solution in various setups, but for the illustration settings are: Filmic tone mode for both Blender and Godot. EEVEE in Blender; Godot glow turned off.

Objects are as follows: random usual color, black usual color, gradient from one of the wooden stripes, Dull/Metal/Shiny/Plastic for blue rings, then red emission and green mirror. 

The back row in Godot images is version without applying a shader at all (with messed up reflections). 
I dont really know why I included it, changes should be compared for the main row in all images versus Blender looks (first image). 

In blender:
<img width="1163" height="369" alt="xHmPklMf3I" src="https://github.com/user-attachments/assets/0e287a91-893a-41bf-bc4c-8c0ae2b633f7" />

In Godot before
<img width="1102" height="317" alt="azT2le8ekV" src="https://github.com/user-attachments/assets/cd7c44d7-8852-46fd-8106-3c64ac0f5523" />

In Godot after the fix
<img width="1114" height="336" alt="k77PVEfoEP" src="https://github.com/user-attachments/assets/85f16717-9e74-4cca-8893-a8ff1e848996" />

Difference when changing Attribute node as well. You can see that first ring looks more correct. 
<img width="404" height="306" alt="ufPC2lP9jz" src="https://github.com/user-attachments/assets/ce9f3ccd-e30d-49d0-ae04-650f4cfd8922" />


