### PR TITLE
Visual Shader: Add strength multiplier for emission

### DIFF
--- a/addons/pixpal_tools/Imphenzia/PixPal/Resources/VS_ImphenziaPixPal.tres
+++ b/addons/pixpal_tools/Imphenzia/PixPal/Resources/VS_ImphenziaPixPal.tres
@@ -1,8 +1,8 @@
-[gd_resource type="VisualShader" load_steps=17 format=3 uid="uid://dxoncufpd7fij"]
+[gd_resource type="VisualShader" format=3 uid="uid://dxoncufpd7fij"]
 
-[ext_resource type="Texture2D" uid="uid://bln4kaydk2cal" path="res://Imphenzia/PixPal/Textures/ImphenziaPixPal_Emission.png" id="1_a0yjt"]
-[ext_resource type="Texture2D" uid="uid://c78hml4g8ipgy" path="res://Imphenzia/PixPal/Textures/ImphenziaPixPal_BaseColor.png" id="2_k4gmu"]
-[ext_resource type="Texture2D" uid="uid://dhp5rmw7s2vcm" path="res://Imphenzia/PixPal/Textures/ImphenziaPixPal_Attributes.png" id="3_8oko3"]
+[ext_resource type="Texture2D" uid="uid://bln4kaydk2cal" path="res://addons/pixpal_tools/Imphenzia/PixPal/Textures/ImphenziaPixPal_Emission.png" id="1_a0yjt"]
+[ext_resource type="Texture2D" uid="uid://c78hml4g8ipgy" path="res://addons/pixpal_tools/Imphenzia/PixPal/Textures/ImphenziaPixPal_BaseColor.png" id="2_k4gmu"]
+[ext_resource type="Texture2D" uid="uid://dhp5rmw7s2vcm" path="res://addons/pixpal_tools/Imphenzia/PixPal/Textures/ImphenziaPixPal_Attributes.png" id="3_8oko3"]
 
 [sub_resource type="VisualShaderNodeVectorDecompose" id="VisualShaderNodeVectorDecompose_frlxv"]
 default_input_values = [0, Vector2(0, 0)]
@@ -15,6 +15,7 @@ op_type = 0
 function = 31
 
 [sub_resource type="VisualShaderNodeTexture" id="VisualShaderNodeTexture_l3ee6"]
+expanded_output_ports = [0]
 texture = ExtResource("1_a0yjt")
 texture_type = 1
 
@@ -27,6 +28,12 @@ constant = 0.141
 
 [sub_resource type="VisualShaderNodeFloatConstant" id="VisualShaderNodeFloatConstant_d7bfu"]
 constant = 0.03
+
+[sub_resource type="VisualShaderNodeVectorCompose" id="VisualShaderNodeVectorCompose_cjrw0"]
+
+[sub_resource type="VisualShaderNodeVectorOp" id="VisualShaderNodeVectorOp_vmrip"]
+default_input_values = [0, Vector3(0, 0, 0), 1, Vector3(20, 20, 20)]
+operator = 2
 
 [sub_resource type="VisualShaderNodeInput" id="VisualShaderNodeInput_vpdvu"]
 input_name = "time"
@@ -48,84 +55,6 @@ operator = 1
 input_name = "uv"
 
 [resource]
-code = "shader_type spatial;
-render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert, specular_schlick_ggx;
-
-uniform sampler2D tex_frg_6;
-uniform sampler2D tex_frg_14 : source_color;
-uniform sampler2D tex_frg_13 : source_color;
-
-
-
-void fragment() {
-// Input:9
-	vec2 n_out9p0 = UV;
-
-
-// VectorDecompose:10
-	float n_out10p0 = n_out9p0.x;
-	float n_out10p1 = n_out9p0.y;
-
-
-// Input:3
-	float n_out3p0 = TIME;
-
-
-// Texture2D:6
-	vec4 n_out6p0 = texture(tex_frg_6, UV);
-
-
-// VectorDecompose:7
-	float n_out7p0 = n_out6p0.x;
-	float n_out7p1 = n_out6p0.y;
-	float n_out7p2 = n_out6p0.z;
-	float n_out7p3 = n_out6p0.w;
-
-
-// FloatOp:4
-	float n_out4p0 = n_out3p0 * n_out7p2;
-
-
-// FloatOp:8
-	float n_out8p0 = n_out10p1 - n_out4p0;
-
-
-// VectorCompose:11
-	vec2 n_out11p0 = vec2(n_out10p0, n_out8p0);
-
-
-// Texture2D:14
-	vec4 n_out14p0 = texture(tex_frg_14, n_out11p0);
-
-
-// FloatFunc:12
-	float n_out12p0 = 1.0 - n_out7p1;
-
-
-// FloatConstant:15
-	float n_out15p0 = 0.141000;
-
-
-// Texture2D:13
-	vec4 n_out13p0 = texture(tex_frg_13, n_out11p0);
-
-
-// FloatConstant:16
-	float n_out16p0 = 0.030000;
-
-
-// Output:0
-	ALBEDO = vec3(n_out14p0.xyz);
-	METALLIC = n_out7p0;
-	ROUGHNESS = n_out12p0;
-	SPECULAR = n_out15p0;
-	EMISSION = vec3(n_out13p0.xyz);
-	CLEARCOAT_ROUGHNESS = n_out16p0;
-
-
-}
-"
-graph_offset = Vector2(-318.78, -203.742)
 nodes/fragment/0/position = Vector2(1380, -380)
 nodes/fragment/3/node = SubResource("VisualShaderNodeInput_vpdvu")
 nodes/fragment/3/position = Vector2(-2200, 1000)
@@ -153,4 +82,8 @@ nodes/fragment/15/node = SubResource("VisualShaderNodeFloatConstant_op67b")
 nodes/fragment/15/position = Vector2(700, -120)
 nodes/fragment/16/node = SubResource("VisualShaderNodeFloatConstant_d7bfu")
 nodes/fragment/16/position = Vector2(840, 520)
-nodes/fragment/connections = PackedInt32Array(3, 0, 4, 0, 6, 0, 7, 0, 7, 2, 4, 1, 9, 0, 10, 0, 10, 1, 8, 0, 4, 0, 8, 1, 10, 0, 11, 0, 8, 0, 11, 1, 7, 0, 0, 2, 7, 1, 12, 0, 11, 0, 13, 0, 12, 0, 0, 3, 13, 0, 0, 5, 14, 0, 0, 0, 11, 0, 14, 0, 15, 0, 0, 4, 16, 0, 0, 14)
+nodes/fragment/17/node = SubResource("VisualShaderNodeVectorCompose_cjrw0")
+nodes/fragment/17/position = Vector2(860, 300)
+nodes/fragment/18/node = SubResource("VisualShaderNodeVectorOp_vmrip")
+nodes/fragment/18/position = Vector2(1120, -40)
+nodes/fragment/connections = PackedInt32Array(3, 0, 4, 0, 6, 0, 7, 0, 7, 2, 4, 1, 9, 0, 10, 0, 10, 1, 8, 0, 4, 0, 8, 1, 10, 0, 11, 0, 8, 0, 11, 1, 7, 0, 0, 2, 7, 1, 12, 0, 11, 0, 13, 0, 12, 0, 0, 3, 14, 0, 0, 0, 11, 0, 14, 0, 15, 0, 0, 4, 16, 0, 0, 14, 13, 1, 17, 0, 13, 2, 17, 1, 13, 3, 17, 2, 17, 0, 18, 0, 18, 0, 0, 5)


### PR DESCRIPTION
Fixes #4 

This adds two nodes in the visual shader that define a strength multiplier, which increases the strength of the emission by a factor of 20.

Note that the commit includes changes to the paths of the textures.